### PR TITLE
fix(ui): remove trailing periods from single-sentence dialog support text

### DIFF
--- a/ui/src/main/composeResources/values-en-rGB/strings.xml
+++ b/ui/src/main/composeResources/values-en-rGB/strings.xml
@@ -92,6 +92,14 @@
     <string name="search_filter_name_only">Name only</string>
     <string name="search_filter_address_only">Address only</string>
 
+    <string name="dialog_title_manage_server_list">Manage server list file</string>
+    <string name="dialog_support_text_manage_server_list">Choose or open the folder for your multiplayer server list file</string>
+    <string name="text_no_file_selected">No file selected</string>
+    <string name="text_server_count">Servers in file: %1$d</string>
+    <string name="button_open_folder">Open folder</string>
+    <string name="cd_open_folder">Open folder</string>
+    <string name="file_picker_title_server_list">Select server list (.dat)</string>
+
     <string name="sort_mode_ping">Lowest ping</string>
     <string name="sort_mode_player_count">Most players online</string>
     <string name="sort_title">Sorting your servers</string>

--- a/ui/src/main/composeResources/values/strings.xml
+++ b/ui/src/main/composeResources/values/strings.xml
@@ -93,7 +93,7 @@
     <string name="search_filter_address_only">Address only</string>
 
     <string name="dialog_title_manage_server_list">Manage server list file</string>
-    <string name="dialog_support_text_manage_server_list">Choose or open the folder for your multiplayer server list file.</string>
+    <string name="dialog_support_text_manage_server_list">Choose or open the folder for your multiplayer server list file</string>
     <string name="text_no_file_selected">No file selected</string>
     <string name="text_server_count">Servers in file: %1$d</string>
     <string name="button_open_folder">Open folder</string>

--- a/ui/src/main/kotlin/com/spoiligaming/explorer/ui/screens/multiplayer/MultiplayerScreen.kt
+++ b/ui/src/main/kotlin/com/spoiligaming/explorer/ui/screens/multiplayer/MultiplayerScreen.kt
@@ -177,7 +177,7 @@ internal fun MultiplayerScreen(
         ) {
             icon(Icons.Filled.DatasetLinked)
             title("External File Change Detected")
-            supportText("The server list file at $conflictPath has been modified externally.")
+            supportText("The server list file at $conflictPath has been modified externally")
             accept(
                 "OK".prominent onClick {
                     scope.launch {
@@ -340,7 +340,7 @@ internal fun MultiplayerScreen(
             title("Delete All?")
             icon(Icons.Filled.DeleteForever)
             supportText(
-                "Are you sure you want to delete all entries? This action cannot be undone.",
+                "Are you sure you want to delete all entries? This action cannot be undone",
             )
             accept(
                 "Delete All".prominent onClick {


### PR DESCRIPTION
closes #10 