### PR TITLE
fix(proguard): keep Compose selection internals to prevent reflection crash

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -150,6 +150,7 @@ compose.desktop.application {
             rootProject.file("proguard/kotlinlogging.pro"),
             rootProject.file("proguard/kotlinx-serialization.pro"),
             rootProject.file("proguard/log4j.pro"),
+            rootProject.file("proguard/HackedSelectionContainer.kt.pro"),
             rootProject.file("proguard/oshi.pro"),
             rootProject.file("proguard/slf4j.pro"),
         )

--- a/proguard/HackedSelectionContainer.kt.pro
+++ b/proguard/HackedSelectionContainer.kt.pro
@@ -1,0 +1,14 @@
+-keepattributes *Annotation*,InnerClasses,EnclosingMethod,Signature,Exceptions
+
+-keep class androidx.compose.foundation.text.selection.** { *; }
+-keep class androidx.compose.ui.text.** { *; }
+-keep class androidx.compose.foundation.text.** { *; }
+-keep class androidx.compose.foundation.ContextMenu* { *; }
+
+-keepclassmembers class **$Companion { *; }
+
+-keep class androidx.compose.foundation.text.selection.SelectionRegistrarKt { *; }
+-keep class androidx.compose.foundation.text.selection.SelectionKt { *; }
+-keep class androidx.compose.foundation.text.selection.SelectionJvmKt { *; }
+-keep class androidx.compose.foundation.text.selection.Selection_desktopKt { *; }
+-keep class androidx.compose.foundation.text.selection.Selection { *; }


### PR DESCRIPTION
hotfix for v2.0.0-alpha04